### PR TITLE
fix shebang check bug

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -57,7 +57,7 @@ fi
 
 # (A)dded (C)opied or (M)odified
 git diff-index --cached --full-index --diff-filter=ACM $against |while read -r line; do
-  mod="$(echo ${line} |cut -d' ' -f1)"
+  mod="$(echo ${line} |cut -d' ' -f2)"
   sha="$(echo ${line} |cut -d' ' -f4)"
   sts="$(echo ${line} |cut -d' ' -f5)"
   pth="$(echo ${line} |cut -d' ' -f6-)"


### PR DESCRIPTION
#### This patch aims to fix 2 bugs:
##### 141 PIPESTATUS

When doing `git cat-file -p ${sha}` on a rather large git object, `head -n1` will close the pipe before the previous command finish writing to pipe. This cause the whole pipeline to return 141 since `set -o pipefail` is set, and in addition, since `set -o errexit` is set, it will immediately exit. This should be fixed by executing `head` directly on the file. Though I'm not sure if there are other concerns here. Removing `set -o pipefail` should resolve this problem too. I'm not sure which is the best way to deal with this bug, I personally used the first approach here.
##### invalid object

When trying to commit a submodule change, the pre-commit hook complaints "bad object". I think it's because the command `git cat-file -p ${sha}` here is executed on some hash-object that can't be "git cat-file -p "ed on. So I added a check on the mode of the line, and only do shebang check on "valid" objects. I'm not that familiar with the internal representation of git though, so I'm not 100 percent sure I'm doing the right mode check.
