### PR TITLE
Add support for eslint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq golang php5-cli ruby python pylint
  - npm install -g npm@1.4
- - npm install -g jshint coffeelint jsonlint js-yaml
- - npm install eslint
+ - npm install -g jshint coffeelint jsonlint js-yaml eslint
  - git config --global user.email "travis@kvz.io"
  - git config --global user.name "Travis test user"
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: node_js
 node_js:
-  - "0.8"
+  - "node"
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq golang php5-cli ruby python pylint
  - npm install -g npm@1.4
  - npm install -g jshint coffeelint jsonlint js-yaml
+ - npm install eslint
  - git config --global user.email "travis@kvz.io"
  - git config --global user.name "Travis test user"
 script: make test

--- a/pre-commit
+++ b/pre-commit
@@ -83,7 +83,9 @@ git diff-index --cached --full-index --diff-filter=ACM $against |while read -r l
   elif [ "${ext}" = "es6" ] || [ "${she}" = "node" ]; then
     # eslint need to be in localfolder, for example using npm install peasant
     # if use global installed eslint not works with .eslintrc
-    cmd="node_modules/.bin/eslint --stdin"
+    # cmd="node_modules/.bin/eslint --stdin"
+    # or use global without .eslintrc
+    cmd="eslint --stdin --no-eslintrc"
     out="red"
   elif [ "${ext}" = "coffee" ] || [ "${she}" = "coffee" ]; then
     # coffeelint unfortunately uses STDOUT for errors, so paint all red

--- a/pre-commit
+++ b/pre-commit
@@ -80,6 +80,11 @@ git diff-index --cached --full-index --diff-filter=ACM $against |while read -r l
     # jshint unfortunately uses STDOUT for errors, so paint all red
     cmd="jshint -"
     out="red"
+  elif [ "${ext}" = "es6" ] || [ "${she}" = "node" ]; then
+    # eslint need to be in localfolder, for example using npm install peasant
+    # if use global installed eslint not works with .eslintrc
+    cmd="node_modules/.bin/eslint --stdin"
+    out="red"
   elif [ "${ext}" = "coffee" ] || [ "${she}" = "coffee" ]; then
     # coffeelint unfortunately uses STDOUT for errors, so paint all red
     cmd="coffeelint --quiet --stdin"

--- a/test.sh
+++ b/test.sh
@@ -43,7 +43,7 @@ mkdir -p "${TESTDIR}"
 pushd "${_}"
   git init
   cp -af "${__DIR__}/pre-commit" ".git/hooks/pre-commit" && chmod 755 "${_}"
-  for ext in go php js rb py bash sh pl coffee xml json yaml; do
+  for ext in go php js es6 rb py bash sh pl coffee xml json yaml; do
     failfile="syntax-fail.${ext}"
     failbuff="#!/bin/bash\n<?php;-)"
     okayfile="syntax-okay.${ext}"


### PR DESCRIPTION
- works with eslint in project directory
- global eslint without support .eslintrc
- if you uncomment second variant eslint ` cmd="node_modules/.bin/eslint --stdin"` you can use them if it's part of project.
