### PR TITLE
Fix YAML test

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -45,7 +45,7 @@ pushd "${_}"
   cp -af "${__DIR__}/pre-commit" ".git/hooks/pre-commit" && chmod 755 "${_}"
   for ext in go php js es6 rb py bash sh pl coffee xml json yaml; do
     failfile="syntax-fail.${ext}"
-    failbuff="#!/bin/bash\n<?php;-)"
+    failbuff="#!/bin/bash\n<?php;-): -"
     okayfile="syntax-okay.${ext}"
     okaybuff=""
     if [ "${ext}" = "xml" ]; then


### PR DESCRIPTION
When running `make test` the script creates a file containing syntax errors to create a linting failure. The content of the file are considered valid YAML, so the tests are failing.

```sh
$ js-yaml -v
3.8.1
$ echo -e '#!/bin/bash\n<?php;-)' > test.yml
$ js-yaml test.yml > /dev/null
$
```

Adding a few characters to the file contents makes it invalid YAML syntax.

```sh
$ echo -e '#!/bin/bash\n<?php;-): -' > test.yml
$ js-yaml test.yml > /dev/null
YAMLException: end of the stream or a document separator is expected at line 2, column 11:
    <?php;-): -
              ^
```