### PR TITLE
Fix Go test

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -52,6 +52,8 @@ pushd "${_}"
       okaybuff="<xml><items></items></xml>"
     elif [ "${ext}" = "json" ]; then
       okaybuff='{"foo": "bar"}'
+    elif [ "${ext}" = "go" ]; then
+      okaybuff='package main'
     fi
 
     # Test failing syntax


### PR DESCRIPTION
On my Mac, the tests for the Go language syntax were failing because a blank file is not considered to be a valid Go source file. The first statement in a Go source file must declare a package name.

```sh
$ go version
go version go1.7.5 darwin/amd64
```
```sh
$ echo '' > test.go
$ gofmt -e test.go > /dev/null
test.go:1:2: expected ';', found 'EOF'
test.go:1:2: expected 'IDENT', found 'EOF'
test.go:1:2: expected 'package', found 'EOF'
```
```sh
$ echo 'package main' > test.go
$ gofmt -e test.go > /dev/null
$
```